### PR TITLE
Feat: Added Swagger-UI for documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.6.4</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Als je de applicatie opstart en je gaat naar http://localhost:8080/swagger-ui/index.html dan zie je daar hoe swagger ui eruit ziet.

Dit kunnen we misschien gebruiken voor de api documentatie?